### PR TITLE
KAN-236 feat: 전체 상품조회 필터링 추가기능

### DIFF
--- a/src/main/java/com/yeonieum/productservice/domain/category/repository/ProductDetailCategoryRepository.java
+++ b/src/main/java/com/yeonieum/productservice/domain/category/repository/ProductDetailCategoryRepository.java
@@ -1,25 +1,9 @@
 package com.yeonieum.productservice.domain.category.repository;
 
 import com.yeonieum.productservice.domain.category.entity.ProductDetailCategory;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import com.yeonieum.productservice.global.enums.ActiveStatus;
-
-import java.util.Optional;
 
 public interface ProductDetailCategoryRepository extends JpaRepository<ProductDetailCategory,Long> {
-
-    @Query("SELECT d FROM ProductDetailCategory d " +
-            "JOIN FETCH d.productList p " +
-            "WHERE d.productDetailCategoryId = :productDetailCategoryId " +
-            "AND p.isPageVisibility = com.yeonieum.productservice.global.enums.ActiveStatus.ACTIVE " +
-            "AND (:isCertification IS NULL OR p.isCertification = :isCertification)")
-    Page<ProductDetailCategory> findByIdWithProducts(@Param("productDetailCategoryId") Long productDetailCategoryId,
-                                                         @Param("isCertification") ActiveStatus isCertification,
-                                                         Pageable pageable);
 
     boolean existsByDetailCategoryName(String detailCategoryName);
 }

--- a/src/main/java/com/yeonieum/productservice/domain/product/dto/memberservice/ProductShoppingResponse.java
+++ b/src/main/java/com/yeonieum/productservice/domain/product/dto/memberservice/ProductShoppingResponse.java
@@ -34,6 +34,16 @@ public class ProductShoppingResponse {
 
     @Getter
     @Builder
+    public static class RetrieveKeywordWithProductsDto {
+
+        private int totalItems;
+        private int totalPages;
+        private boolean lastPage;
+        private List<SearchProductInformationDto> searchProductInformationDtoList;
+    }
+
+    @Getter
+    @Builder
     public static class SearchProductInformationDto {
 
         private Long productId;

--- a/src/main/java/com/yeonieum/productservice/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/yeonieum/productservice/domain/product/repository/ProductRepository.java
@@ -47,5 +47,13 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("SELECT p FROM Product p WHERE LOWER(p.productName) LIKE LOWER(CONCAT('%', :keyword, '%')) AND p.isPageVisibility = com.yeonieum.productservice.global.enums.ActiveStatus.ACTIVE")
     Page<Product> findByProductNameContainingAndIsActive(@Param("keyword") String keyword, Pageable pageable);
 
+    @Query("SELECT p FROM Product p " +
+            "WHERE p.productDetailCategory.productDetailCategoryId = :productDetailCategoryId " +
+            "AND p.isPageVisibility = com.yeonieum.productservice.global.enums.ActiveStatus.ACTIVE " +
+            "AND (:isCertification IS NULL OR p.isCertification = :isCertification)")
+    Page<Product> findActiveProductsByDetailCategoryId(@Param("productDetailCategoryId") Long productDetailCategoryId,
+                                                       @Param("isCertification") ActiveStatus isCertification,
+                                                       Pageable pageable);
+
 
 }

--- a/src/main/java/com/yeonieum/productservice/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/yeonieum/productservice/domain/product/repository/ProductRepository.java
@@ -44,4 +44,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("SELECT p FROM Product p WHERE p.productId = :productId AND p.isPageVisibility = com.yeonieum.productservice.global.enums.ActiveStatus.ACTIVE")
     Optional<Product> findByIdAndIsActive(@Param("productId") Long productId);
 
+    @Query("SELECT p FROM Product p WHERE LOWER(p.productName) LIKE LOWER(CONCAT('%', :keyword, '%')) AND p.isPageVisibility = com.yeonieum.productservice.global.enums.ActiveStatus.ACTIVE")
+    Page<Product> findByProductNameContainingAndIsActive(@Param("keyword") String keyword, Pageable pageable);
+
+
 }

--- a/src/main/java/com/yeonieum/productservice/domain/product/service/memberservice/ProductShoppingService.java
+++ b/src/main/java/com/yeonieum/productservice/domain/product/service/memberservice/ProductShoppingService.java
@@ -7,7 +7,6 @@ import com.yeonieum.productservice.domain.category.repository.ProductDetailCateg
 import com.yeonieum.productservice.domain.product.dto.memberservice.ProductShoppingResponse;
 import com.yeonieum.productservice.domain.product.entity.Product;
 import com.yeonieum.productservice.domain.product.repository.ProductRepository;
-import com.yeonieum.productservice.domain.review.entity.ProductReview;
 import com.yeonieum.productservice.domain.review.repository.ProductReviewRepository;
 import com.yeonieum.productservice.global.enums.ActiveStatus;
 import jakarta.transaction.Transactional;
@@ -74,8 +73,6 @@ public class ProductShoppingService {
                 .lastPage(productsPage.isLast())
                 .build();
     }
-
-
 
     /**
      * 상세 카테고리 조회시, 해당 카테고리의 상품 조회
@@ -163,6 +160,44 @@ public class ProductShoppingService {
                 .averageScore(averageScore)
                 .build();
     }
-}
 
+    /**
+     * 키워드로 상품 조회
+     * @param keyword 상품 키워드(이름)
+     * @throws IllegalArgumentException 존재하지 않는 상품 ID인 경우
+     * @return 상품의 정보
+     */
+    @Transactional
+    public ProductShoppingResponse.RetrieveKeywordWithProductsDto retrieveKeywordWithProductsDto(String keyword, Pageable pageable){
+
+        Page<Product> productsPage = productRepository.findByProductNameContainingAndIsActive(keyword, pageable);
+
+        List<ProductShoppingResponse.SearchProductInformationDto> searchProductInformationDtoList = productsPage.getContent().stream().map(product -> {
+            int reviewCount = productReviewRepository.countByProductId(product.getProductId());
+            double averageScore = productReviewRepository.findAverageScoreByProductId(product.getProductId());
+
+            return ProductShoppingResponse.SearchProductInformationDto.builder()
+                    .productId(product.getProductId())
+                    .productName(product.getProductName())
+                    .productDescription(product.getProductDescription())
+                    .productImage(product.getProductImage())
+                    .baseDiscountRate(product.getBaseDiscountRate())
+                    .regularDiscountRate(product.getRegularDiscountRate())
+                    .productPrice(product.getProductPrice())
+                    .calculatedBasePrice(product.getCalculatedBasePrice())
+                    .isRegularSale(product.getIsRegularSale().getCode())
+                    .reviewCount(reviewCount)
+                    .averageScore(averageScore)
+                    .build();
+        }).collect(Collectors.toList());
+
+        return ProductShoppingResponse.RetrieveKeywordWithProductsDto.builder()
+                .totalItems((int) productsPage.getTotalElements())
+                .totalPages(productsPage.getTotalPages())
+                .lastPage(productsPage.isLast())
+                .searchProductInformationDtoList(searchProductInformationDtoList)
+                .build();
+
+    }
+}
 

--- a/src/main/java/com/yeonieum/productservice/domain/product/service/memberservice/ProductShoppingService.java
+++ b/src/main/java/com/yeonieum/productservice/domain/product/service/memberservice/ProductShoppingService.java
@@ -164,8 +164,7 @@ public class ProductShoppingService {
     /**
      * 키워드로 상품 조회
      * @param keyword 상품 키워드(이름)
-     * @throws IllegalArgumentException 존재하지 않는 상품 ID인 경우
-     * @return 상품의 정보
+     * @return 해당 키워드의 상품들 정보
      */
     @Transactional
     public ProductShoppingResponse.RetrieveKeywordWithProductsDto retrieveKeywordWithProductsDto(String keyword, Pageable pageable){

--- a/src/main/java/com/yeonieum/productservice/global/paging/PageableUtil.java
+++ b/src/main/java/com/yeonieum/productservice/global/paging/PageableUtil.java
@@ -1,0 +1,23 @@
+package com.yeonieum.productservice.global.paging;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public class PageableUtil {
+
+    public static Pageable createPageable(int page, int size, String sort, String direction) {
+        Sort.Direction dir = Sort.Direction.fromString(direction);
+        switch (sort) {
+            case "productName":
+            case "productPrice":
+            case "averageScore":
+                break;
+            default:
+                sort = "productName";
+                break;
+        }
+        return PageRequest.of(page, size, Sort.by(dir, sort));
+    }
+}
+

--- a/src/main/java/com/yeonieum/productservice/web/controller/ProductShoppingController.java
+++ b/src/main/java/com/yeonieum/productservice/web/controller/ProductShoppingController.java
@@ -80,4 +80,24 @@ public class ProductShoppingController {
                 .successCode(SuccessCode.SELECT_SUCCESS)
                 .build(), HttpStatus.OK);
     }
+
+    @Operation(summary = "키워드로 상품 조회", description = "입력한 키워드를 가진 상품을 조회하는 기능입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "키워드 상품 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "키워드 상품 조회 실패")
+    })
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse> retrieveSearchKeywordProduct(@RequestParam("keyword") String keyword,
+                                                                    @RequestParam(defaultValue = "0") int startPage,
+                                                                    @RequestParam(defaultValue = "10") int pageSize) {
+
+        Pageable pageable = PageRequest.of(startPage, pageSize);
+
+        ProductShoppingResponse.RetrieveKeywordWithProductsDto retrieveKeywordWithProducts = productShoppingService.retrieveKeywordWithProductsDto(keyword,pageable);
+
+        return new ResponseEntity<>(ApiResponse.builder()
+                .result(retrieveKeywordWithProducts)
+                .successCode(SuccessCode.SELECT_SUCCESS)
+                .build(), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/yeonieum/productservice/web/controller/ProductShoppingController.java
+++ b/src/main/java/com/yeonieum/productservice/web/controller/ProductShoppingController.java
@@ -32,8 +32,11 @@ public class ProductShoppingController {
     public ResponseEntity<ApiResponse> retrieveCategoryWithProducts(@PathVariable Long categoryId,
                                                                     @RequestParam(value = "isCertification", required = false) ActiveStatus isCertification,
                                                                     @RequestParam(defaultValue = "0") int startPage,
-                                                                    @RequestParam(defaultValue = "10") int pageSize) {
-        Pageable pageable = PageRequest.of(startPage, pageSize);
+                                                                    @RequestParam(defaultValue = "10") int pageSize,
+                                                                    @RequestParam(defaultValue = "productName") String sort,
+                                                                    @RequestParam(defaultValue = "asc") String direction) {
+
+        Pageable pageable = PageableUtil.createPageable(startPage, pageSize, sort, direction);
 
         ProductShoppingResponse.RetrieveCategoryWithProductsDto retrieveCategoryWithProducts =
                 productShoppingService.retrieveCategoryWithProducts(categoryId, isCertification, pageable);
@@ -95,6 +98,7 @@ public class ProductShoppingController {
                                                                     @RequestParam(defaultValue = "asc") String direction) {
 
         Pageable pageable = PageableUtil.createPageable(startPage, pageSize, sort, direction);
+
         ProductShoppingResponse.RetrieveKeywordWithProductsDto retrieveKeywordWithProducts =
                 productShoppingService.retrieveKeywordWithProductsDto(keyword, pageable);
 

--- a/src/main/java/com/yeonieum/productservice/web/controller/ProductShoppingController.java
+++ b/src/main/java/com/yeonieum/productservice/web/controller/ProductShoppingController.java
@@ -4,6 +4,7 @@ import com.yeonieum.productservice.domain.product.dto.memberservice.ProductShopp
 import com.yeonieum.productservice.domain.product.entity.Product;
 import com.yeonieum.productservice.domain.product.service.memberservice.ProductShoppingService;
 import com.yeonieum.productservice.global.enums.ActiveStatus;
+import com.yeonieum.productservice.global.paging.PageableUtil;
 import com.yeonieum.productservice.global.responses.ApiResponse;
 import com.yeonieum.productservice.global.responses.code.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -89,11 +90,13 @@ public class ProductShoppingController {
     @GetMapping("/search")
     public ResponseEntity<ApiResponse> retrieveSearchKeywordProduct(@RequestParam("keyword") String keyword,
                                                                     @RequestParam(defaultValue = "0") int startPage,
-                                                                    @RequestParam(defaultValue = "10") int pageSize) {
+                                                                    @RequestParam(defaultValue = "10") int pageSize,
+                                                                    @RequestParam(defaultValue = "productName") String sort,
+                                                                    @RequestParam(defaultValue = "asc") String direction) {
 
-        Pageable pageable = PageRequest.of(startPage, pageSize);
-
-        ProductShoppingResponse.RetrieveKeywordWithProductsDto retrieveKeywordWithProducts = productShoppingService.retrieveKeywordWithProductsDto(keyword,pageable);
+        Pageable pageable = PageableUtil.createPageable(startPage, pageSize, sort, direction);
+        ProductShoppingResponse.RetrieveKeywordWithProductsDto retrieveKeywordWithProducts =
+                productShoppingService.retrieveKeywordWithProductsDto(keyword, pageable);
 
         return new ResponseEntity<>(ApiResponse.builder()
                 .result(retrieveKeywordWithProducts)

--- a/src/main/java/com/yeonieum/productservice/web/controller/ProductShoppingController.java
+++ b/src/main/java/com/yeonieum/productservice/web/controller/ProductShoppingController.java
@@ -57,8 +57,11 @@ public class ProductShoppingController {
     public ResponseEntity<ApiResponse> retrieveDetailCategoryWithProducts(@PathVariable Long detailCategoryId,
                                                                           @RequestParam(value = "isCertification", required = false) ActiveStatus isCertification,
                                                                           @RequestParam(defaultValue = "0") int startPage,
-                                                                          @RequestParam(defaultValue = "10") int pageSize) {
-        Pageable pageable = PageRequest.of(startPage, pageSize);
+                                                                          @RequestParam(defaultValue = "10") int pageSize,
+                                                                          @RequestParam(defaultValue = "productName") String sort,
+                                                                          @RequestParam(defaultValue = "asc") String direction) {
+
+        Pageable pageable = PageableUtil.createPageable(startPage, pageSize, sort, direction);
 
         ProductShoppingResponse.RetrieveDetailCategoryWithProductsDto retrieveDetailCategoryWithProducts =
                 productShoppingService.retrieveDetailCategoryWithProducts(detailCategoryId, isCertification, pageable);
@@ -68,6 +71,7 @@ public class ProductShoppingController {
                 .successCode(SuccessCode.SELECT_SUCCESS)
                 .build(), HttpStatus.OK);
     }
+
 
     @Operation(summary = "상세 상품 조회", description = "선택한 상품의 정보를 조회하는 기능입니다.")
     @ApiResponses({


### PR DESCRIPTION
<!--

PR 제목 예시

title : [FEAT] 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 전체 상품조회 필터링, 정렬 기능 구현

## #️⃣관련 이슈

- #{236}


## 📝세부 작업 내용

- [x] 키워드 검색 필터링 기능 (이름순, 가격순)
- [x] 카테고리 검색시 상품 정렬 기능 (이름순, 가격순)
- [x] 상세 카테고리 검색시 상품 정렬 기능 (이름순, 가격순)


## 💬참고 사항

- 평균별점순도 고려중입니다. 현재 평균별점을 상품엔티티 속성으로 가지고 있어도 되는지에 대한 고민을 해결중입니다.
- 추후, 통계데이터가 들어오면 판매순, 조회순 기능도 추가하겠습니다.
