### PR TITLE
KAN-330 refactor: 상품서비스 페치조인 페이징 리팩토링

### DIFF
--- a/src/main/java/com/yeonieum/productservice/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/yeonieum/productservice/domain/product/repository/ProductRepository.java
@@ -38,8 +38,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             "WHERE p.customer_id = :customerId", nativeQuery = true)
     List<RetrieveAdvertisementProductResponseDto> findAllAdvertisementProduct(@Param("customerId") Long customerId);
 
-    @Query("SELECT p FROM Product p LEFT JOIN FETCH p.productReviewList WHERE p.productId = :productId")
-    Optional<Product> findByIdWithReviews(@Param("productId") Long productId);
+//    @Query("SELECT p FROM Product p LEFT JOIN FETCH p.productReviewList WHERE p.productId = :productId")
+//    Optional<Product> findByIdWithReviews(@Param("productId") Long productId);
 
     @Query("SELECT p FROM Product p " +
             "JOIN FETCH p.productDetailCategory pdc " +

--- a/src/main/java/com/yeonieum/productservice/domain/review/repository/ProductReviewRepository.java
+++ b/src/main/java/com/yeonieum/productservice/domain/review/repository/ProductReviewRepository.java
@@ -1,6 +1,8 @@
 package com.yeonieum.productservice.domain.review.repository;
 
 import com.yeonieum.productservice.domain.review.entity.ProductReview;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,4 +17,6 @@ public interface ProductReviewRepository extends JpaRepository<ProductReview, Lo
     @Query("SELECT COALESCE(AVG(r.reviewScore), 0) FROM ProductReview r WHERE r.product.productId = :productId")
     double findAverageScoreByProductId(@Param("productId") Long productId);
 
+    @Query("SELECT pr FROM ProductReview pr WHERE pr.product.productId = :productId")
+    Page<ProductReview> findByProductId(@Param("productId") Long productId, Pageable pageable);
 }

--- a/src/main/java/com/yeonieum/productservice/domain/review/service/ProductReviewService.java
+++ b/src/main/java/com/yeonieum/productservice/domain/review/service/ProductReviewService.java
@@ -1,5 +1,7 @@
 package com.yeonieum.productservice.domain.review.service;
 
+import com.yeonieum.productservice.domain.customer.dto.CustomerResponse;
+import com.yeonieum.productservice.domain.customer.entity.Customer;
 import com.yeonieum.productservice.domain.product.entity.Product;
 import com.yeonieum.productservice.domain.product.repository.ProductRepository;
 import com.yeonieum.productservice.domain.review.dto.ProductReviewRequest;
@@ -8,8 +10,11 @@ import com.yeonieum.productservice.domain.review.entity.ProductReview;
 import com.yeonieum.productservice.domain.review.repository.ProductReviewRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -22,20 +27,21 @@ public class ProductReviewService {
 
     /**
      * 상품 리뷰 등록
+     *
      * @param registerProductReviewDto 상품 리뷰를 등록할 정보 DTO
-     * @throws IllegalArgumentException 존재하지 않는 상품 ID인 경우
-     * @throws IllegalStateException 해당 상품에 대한 회원의 리뷰가 이미 존재하는 경우
      * @return 성공 여부
+     * @throws IllegalArgumentException 존재하지 않는 상품 ID인 경우
+     * @throws IllegalStateException    해당 상품에 대한 회원의 리뷰가 이미 존재하는 경우
      */
     @Transactional
-    public boolean registerProductReview(ProductReviewRequest.RegisterProductReviewDto registerProductReviewDto){
+    public boolean registerProductReview(ProductReviewRequest.RegisterProductReviewDto registerProductReviewDto) {
 
         //상품을 구해만 회원인지에 대한 로직 필요
 
         Product product = productRepository.findById(registerProductReviewDto.getProductId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품 ID 입니다."));
 
-        if(productReviewRepository.existsByMemberId(registerProductReviewDto.getMemberId())){
+        if (productReviewRepository.existsByMemberId(registerProductReviewDto.getMemberId())) {
             throw new IllegalStateException("이미 해당 회원이 작성한 리뷰가 존재합니다.");
         }
 
@@ -54,12 +60,13 @@ public class ProductReviewService {
 
     /**
      * 상품 리뷰 삭제
+     *
      * @param productReviewId 상품 리뷰 ID
-     * @throws IllegalArgumentException 존재하지 않는 상품 리뷰 ID인 경우
      * @return 성공 여부
+     * @throws IllegalArgumentException 존재하지 않는 상품 리뷰 ID인 경우
      */
     @Transactional
-    public boolean deleteProductReview(Long productReviewId){
+    public boolean deleteProductReview(Long productReviewId) {
 
         if (productReviewRepository.existsById(productReviewId)) {
             productReviewRepository.deleteById(productReviewId);
@@ -71,26 +78,23 @@ public class ProductReviewService {
 
     /**
      * 선택한 상품 조회시, 해당 상품의 리뷰 조회
+     *
      * @param productId 상품 ID
-     * @throws IllegalArgumentException 존재하지 않는 상품 ID인 경우
      * @return 상품리뷰에 대한 정보
+     * @throws IllegalArgumentException 존재하지 않는 상품 ID인 경우
      */
     @Transactional
-    public List<ProductReviewResponse.RetrieveProductWithReviewsDto> retrieveProductWithReviews(Long productId){
-        Product product = productRepository.findByIdWithReviews(productId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품 ID 입니다."));
+    public Page<ProductReviewResponse.RetrieveProductWithReviewsDto> retrieveProductWithReviews(Long productId, Pageable pageable) {
 
-        List<ProductReviewResponse.RetrieveProductWithReviewsDto> retrieveProductWithReviewsDtoList = product.getProductReviewList().stream()
-                .map(productReview -> { return ProductReviewResponse.RetrieveProductWithReviewsDto.builder()
-                        .productReviewId(productReview.getProductReviewId())
-                        .memberId(productReview.getMemberId())
-                        .createDate(productReview.getCreateDate())
-                        .reviewContent(productReview.getReviewContent())
-                        .reviewImage(productReview.getReviewImage())
-                        .reviewScore(productReview.getReviewScore())
-                        .build();
-        }).collect(Collectors.toList());
+        Page<ProductReview> productReviews = productReviewRepository.findByProductId(productId, pageable);
 
-        return retrieveProductWithReviewsDtoList;
+        return productReviews.map(review -> ProductReviewResponse.RetrieveProductWithReviewsDto.builder()
+                .productReviewId(review.getProductReviewId())
+                .memberId(review.getMemberId())
+                .createDate(review.getCreateDate())
+                .reviewContent(review.getReviewContent())
+                .reviewImage(review.getReviewImage())
+                .reviewScore(review.getReviewScore())
+                .build());
     }
 }

--- a/src/main/java/com/yeonieum/productservice/web/controller/ReviewController.java
+++ b/src/main/java/com/yeonieum/productservice/web/controller/ReviewController.java
@@ -1,5 +1,6 @@
 package com.yeonieum.productservice.web.controller;
 
+import com.yeonieum.productservice.domain.customer.dto.CustomerResponse;
 import com.yeonieum.productservice.domain.review.dto.ProductReviewRequest;
 import com.yeonieum.productservice.domain.review.dto.ProductReviewResponse;
 import com.yeonieum.productservice.domain.review.service.ProductReviewService;
@@ -8,6 +9,9 @@ import com.yeonieum.productservice.global.responses.code.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -59,9 +63,15 @@ public class ReviewController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "상품 리뷰 조회 실패")
     })
     @GetMapping("/{productId}")
-    public ResponseEntity<ApiResponse> retrieveProductReviews(@PathVariable Long productId) {
+    public ResponseEntity<ApiResponse> retrieveProductReviews(
+            @PathVariable Long productId,
+            @RequestParam(defaultValue = "0") int startPage,
+            @RequestParam(defaultValue = "10") int pageSize) {
 
-        List<ProductReviewResponse.RetrieveProductWithReviewsDto> retrieveProductWithReviews = productReviewService.retrieveProductWithReviews(productId);
+        Pageable pageable =  PageRequest.of(startPage, pageSize);
+
+        Page<ProductReviewResponse.RetrieveProductWithReviewsDto> retrieveProductWithReviews
+                = productReviewService.retrieveProductWithReviews(productId, pageable);
 
         return new ResponseEntity<>(ApiResponse.builder()
                 .result(retrieveProductWithReviews)


### PR DESCRIPTION
<!--

PR 제목 예시

title : [FEAT] 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 상품서비스 페치조인 페이징 리팩토링

## #️⃣관련 이슈

- Close#{330}

## 📝세부 작업 내용

- [x] 상품리뷰 조회 방법 수정

## 💬참고 사항

- 기존에는 상품의 상품리뷰 조회시 상품테이블에서 페치조인을 사용해 상품리뷰테이블을 조회했습니다.
- 수정된 방법은 상품리뷰테이블에서 상품ID로 상품리뷰를 찾아서 페이징적용까지 완료했습니다.

- 페치조인과 페이징 동시 적용 문제
  - 결과 행의 수가 불명확: 각 테이블이 가져오는 연관된 테이블 수에 따라 결과 집합의 크기가 달라지기 때문에, 첫 페이지에 정확히 몇개의 데이터가 표시하는 것이 불가능할 수 있습니다.
  - 정확한 페이징 불가능: 결과 집합의 각 데이터에 대해 동일한 수의 연관 데이터가가 존재하지 않기 때문에, 페이징 쿼리가 예상과 다른 수의 상품을 반환할 수 있습니다.

- 해결방법
  - 일대다 관계에서의 접근이 아닌, 다대일 관계에서 접근