### PR TITLE
KAN-433 feat: 상품 키워드검색 기능개선

### DIFF
--- a/src/main/java/com/yeonieum/productservice/domain/product/dto/memberservice/ProductShoppingResponse.java
+++ b/src/main/java/com/yeonieum/productservice/domain/product/dto/memberservice/ProductShoppingResponse.java
@@ -145,4 +145,12 @@ public class ProductShoppingResponse {
                     .build();
         }
     }
+
+    @Getter
+    @Builder
+    public static class OfSearchRank {
+        private String searchName;
+        private long searchScore;
+        private int rankChange; // 이전 검색어 순위와 비교하여 상승하거나 떨어진 순위 값
+    }
 }

--- a/src/main/java/com/yeonieum/productservice/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/yeonieum/productservice/domain/product/repository/ProductRepository.java
@@ -76,4 +76,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
                                                            Pageable pageable);
     @Query("SELECT p FROM Product p WHERE p.productDetailCategory IN :categories AND p.isPageVisibility = com.yeonieum.productservice.global.enums.ActiveStatus.ACTIVE")
     Page<Product> findByProductDetailCategoryIn(@Param("categories") List<ProductDetailCategory> categories, Pageable pageable);
+
+    @Query("SELECT p FROM Product p WHERE p.productName LIKE CONCAT('%', :productName, '%') AND p.isPageVisibility = com.yeonieum.productservice.global.enums.ActiveStatus.ACTIVE")
+    List<Product> findByNameContaining(@Param("productName") String productName);
 }

--- a/src/main/java/com/yeonieum/productservice/domain/product/service/memberservice/ProductShoppingService.java
+++ b/src/main/java/com/yeonieum/productservice/domain/product/service/memberservice/ProductShoppingService.java
@@ -1,5 +1,6 @@
 package com.yeonieum.productservice.domain.product.service.memberservice;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yeonieum.productservice.domain.category.entity.ProductCategory;
 import com.yeonieum.productservice.domain.category.entity.ProductDetailCategory;
 import com.yeonieum.productservice.domain.category.repository.ProductCategoryRepository;
@@ -26,8 +27,7 @@ public class ProductShoppingService {
     private final ProductCategoryRepository productCategoryRepository;
     private final ProductDetailCategoryRepository productDetailCategoryRepository;
     private final ProductRepository productRepository;
-    private final RedisTemplate redisTemplate;
-
+    private final RedisTemplate<String, Object> redisTemplate;
 
     /**
      * 카테고리의 상품 목록 조회
@@ -133,45 +133,6 @@ public class ProductShoppingService {
     }
 
     /**
-     * 상품 필터링 조회 (키워드, 친환경)
-     * @param keyword 상품 키워드(이름)
-     * @param isCertification 인증서 유무
-     * @param pageable 페이징 정보
-     * @return 조회된 상품 목록이 포함된 Page 객체
-     */
-    @Transactional
-    public Page<ProductShoppingResponse.OfSearchProductInformation> retrieveFilteringProducts(
-            String keyword, ActiveStatus isCertification, Pageable pageable){
-
-        Page<Product> products;
-
-        if (keyword != null && !keyword.trim().isEmpty()) {
-            Set<ProductDetailCategory> matchingCategories = new HashSet<>();
-            List<String> keywords = splitKeywords(keyword);
-
-            for (String singleKeyword : keywords) {
-                List<ProductDetailCategory> categories = productDetailCategoryRepository.findByNameContaining(singleKeyword);
-                matchingCategories.addAll(categories);
-            }
-
-            if (!matchingCategories.isEmpty()) {
-                return productRepository.findByProductDetailCategoryIn(new ArrayList<>(matchingCategories), pageable)
-                        .map(ProductShoppingResponse.OfSearchProductInformation::convertedBy);
-            }
-        }
-
-        // 키워드가 없고 인증 상태만 있는 경우, 인증 상태에 따라 검색
-        if (isCertification != null) {
-            return productRepository.findActiveCertifiableProductsByProductId(isCertification, pageable)
-                    .map(ProductShoppingResponse.OfSearchProductInformation::convertedBy);
-        }
-
-        // 키워드와 인증 상태 모두 없는 경우 전체 상품 조회
-        return productRepository.findAllByIsActive(pageable)
-                .map(ProductShoppingResponse.OfSearchProductInformation::convertedBy);
-    }
-
-    /**
      * 업체별 상품 조회
      * @param customerId 고객 ID
      * @param detailCategoryId 상세 카테고리 ID
@@ -185,6 +146,67 @@ public class ProductShoppingService {
         Page<Product> products = productRepository.findByCustomerIdAndIsActiveAndCategoryId(customerId, detailCategoryId, pageable);
 
         return products.map(ProductShoppingResponse.OfSearchProductInformation::convertedBy);
+    }
+
+    /**
+     * 상품 필터링 조회 (키워드, 친환경)
+     * @param keyword 상품 키워드(이름)
+     * @param isCertification 인증서 유무
+     * @param pageable 페이징 정보
+     * @return 조회된 상품 목록이 포함된 Page 객체
+     */
+    @Transactional
+    public Page<ProductShoppingResponse.OfSearchProductInformation> retrieveFilteringProducts(
+            String keyword, ActiveStatus isCertification, Pageable pageable){
+
+        // 모든 검색 결과를 담을 Set
+        Set<Product> allProducts = new HashSet<>();
+
+        // 키워드가 유효한 경우 처리
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            // 매칭되는 카테고리를 저장할 Set
+            Set<ProductDetailCategory> matchingCategories = new HashSet<>();
+
+            // 키워드를 분할
+            List<String> keywords = splitKeywords(keyword);
+
+            for (String singleKeyword : keywords) {
+                // 각 키워드에 대해 카테고리 검색
+                List<ProductDetailCategory> categories = productDetailCategoryRepository.findByNameContaining(singleKeyword);
+                matchingCategories.addAll(categories);
+
+                // 각 키워드에 대해 상품명 검색
+                List<Product> productsByName = productRepository.findByNameContaining(singleKeyword);
+                allProducts.addAll(productsByName);
+            }
+
+            // 매칭되는 카테고리가 있는 경우, 카테고리 내의 상품을 검색하여 결과에 추가
+            if (!matchingCategories.isEmpty()) {
+                List<Product> productsByCategory = productRepository.findByProductDetailCategoryIn(new ArrayList<>(matchingCategories), pageable).getContent();
+                allProducts.addAll(productsByCategory);
+            }
+
+            // 검색 결과가 없는 경우 예외를 던짐
+            if (allProducts.isEmpty()) {
+                throw new IllegalStateException(keyword + "에 대한 검색결과가 없습니다. 다른 검색어를 입력해 주세요.");
+            }
+
+            // 중복 제거 후 페이징 처리
+            List<Product> distinctProducts = allProducts.stream().distinct().collect(Collectors.toList());
+
+            return new PageImpl<>(distinctProducts, pageable, distinctProducts.size())
+                    .map(ProductShoppingResponse.OfSearchProductInformation::convertedBy);
+        }
+
+        // 키워드가 없고 인증 상태만 있는 경우, 인증 상태에 따라 검색
+        if (isCertification != null) {
+            return productRepository.findActiveCertifiableProductsByProductId(isCertification, pageable)
+                    .map(ProductShoppingResponse.OfSearchProductInformation::convertedBy);
+        }
+
+        // 키워드와 인증 상태 모두 없는 경우 전체 상품 조회
+        return productRepository.findAllByIsActive(pageable)
+                .map(ProductShoppingResponse.OfSearchProductInformation::convertedBy);
     }
 
     /**

--- a/src/main/java/com/yeonieum/productservice/web/controller/ProductShoppingController.java
+++ b/src/main/java/com/yeonieum/productservice/web/controller/ProductShoppingController.java
@@ -16,6 +16,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/shopping/product")
 @RequiredArgsConstructor


### PR DESCRIPTION
<!--

PR 제목 예시

title : [FEAT] 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 상품 키워드검색 기능개선

## #️⃣관련 이슈

- Close#{433}

## 📝세부 작업 내용

- [x] 상품 키워드검색 기능 개선
- [x] 상품 키워드 검색시, 1차적으로 카테고리이름으로 검색
- [x] 2차적으로 상품명으로도 검색 (중복 제거)

## 💬참고 사항
- 키워드 검색: 상품의 이름으로 키워드 검색을 하지않고, 키워드가 포함된 카테고리 내 상품 전체 조회
- 목적: 판매자들의 상품을 최대한 많이 노출되게 하기 위해서

- 기존의 키워드 검색기능
  - 사용자가 검색한 단어 띄어쓰기로 분할 처리
  - 검색한 단어가 카테고리 이름과 매핑되면 카테고리에 포함된 전체 상품 조회

- 기존의 키워드 검색의 문제점
  - 전제) ‘사과’라는 카테고리만 존재
  - ‘김효성 사과’ 검색시,  ‘김효성’, ‘사과’로 카테고리내 분할 조회
  - ‘사과’카테고리가 존재하기에, ‘사과’ 카테고리로 상품조회시 검색가능
  - 하지만, ‘김효성’ 검색시 ‘김효성’카테고리는 존재하지 않기 때문에, ‘김효성 사과’사과는 출력되지 않는 문제 발생

- 개선된 내용
  - 1차적으로 분할된 키워드를 통해 카테고리내 분할 조회
  - ‘김효성’, ‘사과’로도 상품이름 검색
  - 중복된 상품 제외
  - 카테고리 상품 + 상품이름을 보여줌으로써, 판매들의 상품 노출 최대화