### PR TITLE
KAN-530 feat: 키워드검색 QueryDSL 사용으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.1'
@@ -44,7 +50,6 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
-
 	// aop
 	implementation 'org.aspectj:aspectjweaver:1.9.7'
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
@@ -57,6 +62,11 @@ dependencies {
 	implementation 'org.springframework.kafka:spring-kafka'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	//querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/yeonieum/productservice/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/yeonieum/productservice/domain/product/repository/ProductRepository.java
@@ -13,7 +13,7 @@ import com.yeonieum.productservice.global.enums.ActiveStatus;
 import java.util.List;
 import java.util.Optional;
 
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
     @Query("SELECT p FROM Product p " +
             "JOIN FETCH p.productDetailCategory pdc " +
             "JOIN FETCH pdc.productCategory pc " +
@@ -75,4 +75,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     @Query("SELECT p FROM Product p WHERE p.productName LIKE CONCAT('%', :productName, '%') AND p.isPageVisibility = com.yeonieum.productservice.global.enums.ActiveStatus.ACTIVE")
     List<Product> findByNameContaining(@Param("productName") String productName);
+
+//    @Query("SELECT DISTINCT p FROM Product p JOIN p.productDetailCategory c WHERE (p.productName LIKE CONCAT('%', :keyword, '%') OR c.detailCategoryName LIKE CONCAT('%', :keyword, '%')) AND p.isPageVisibility = com.yeonieum.productservice.global.enums.ActiveStatus.ACTIVE")
+//    Page<Product> findByKeywords(List<String> keywords, Pageable pageable);
+
 }

--- a/src/main/java/com/yeonieum/productservice/domain/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/yeonieum/productservice/domain/product/repository/ProductRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.yeonieum.productservice.domain.product.repository;
+
+import com.yeonieum.productservice.domain.product.entity.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface ProductRepositoryCustom {
+
+    Page<Product> findByKeywords(List<String> keywords, Pageable pageable);
+}

--- a/src/main/java/com/yeonieum/productservice/domain/product/repository/ProductRepositoryCustomImpl.java
+++ b/src/main/java/com/yeonieum/productservice/domain/product/repository/ProductRepositoryCustomImpl.java
@@ -1,0 +1,56 @@
+package com.yeonieum.productservice.domain.product.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.yeonieum.productservice.domain.category.entity.QProductDetailCategory;
+import com.yeonieum.productservice.domain.product.entity.Product;
+import com.yeonieum.productservice.domain.product.entity.QProduct;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public Page<Product> findByKeywords(List<String> keywords, Pageable pageable) {
+        JPAQueryFactory queryFactory = new JPAQueryFactory(em);
+        QProduct product = QProduct.product;
+        QProductDetailCategory category = QProductDetailCategory.productDetailCategory;
+
+        // 쿼리 생성
+        var query = queryFactory.selectFrom(product)
+                .join(product.productDetailCategory, category);
+
+        // WHERE 절 동적 생성
+        BooleanExpression predicate = keywords.stream()
+                .map(k -> product.productName.like("%" + k + "%")
+                        .or(category.detailCategoryName.like("%" + k + "%")))
+                .reduce(BooleanExpression::or)
+                .orElse(null);
+
+        query.where(predicate).distinct();
+
+        // 쿼리 결과 가져오기 및 페이징 처리
+        List<Product> productList = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 총 개수 가져오기
+        long total = query.fetchCount();
+
+        return new PageImpl<>(productList, pageable, total);
+    }
+}


### PR DESCRIPTION
<!--

PR 제목 예시

title : [FEAT] 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 키워드검색 QueryDSL 사용으로 변경

## #️⃣관련 이슈

- Close#{530}

## 📝세부 작업 내용

- [x] 키워드 검색 QueryDSL 사용으로 변경

## 💬참고 사항

- 문제점

  - 키워드 검색시, 여러 키워드를 한번에 검색해야했음.
  - 기존의 @Query 어노테이션을 사용한 방법은 List<String>에 대한 처리가 기술적으로 제한되었음
  - set구조와 페이징을 같이하여 전체 상품 수를 못 읽어오고, 페이징처리가 누적되는 문제 발생

- 해결책
  - QueryDSL로 타입-세이프 쿼리를 동적으로 생성
