### PR TITLE
KAN-603 feat: 도메인별 오류코드 정의

### DIFF
--- a/src/main/java/com/yeonieum/productservice/domain/cart/exception/CartExceptionCode.java
+++ b/src/main/java/com/yeonieum/productservice/domain/cart/exception/CartExceptionCode.java
@@ -4,8 +4,8 @@ import com.yeonieum.productservice.global.exceptions.code.CustomExceptionCode;
 
 public enum CartExceptionCode implements CustomExceptionCode {
     CART_TYPE_NOT_FOUND(1000, "존재하지 않는 장바구니타입 ID 입니다."),
-    CART_NOT_FOUND(1100, "존재하지 않는 장바구니 ID 입니다."),
-    QUANTITY_BELOW_MINIMUM(1200, "상품 수량은 1개 이상이어야 합니다.");
+    CART_NOT_FOUND(1001, "존재하지 않는 장바구니 ID 입니다."),
+    QUANTITY_BELOW_MINIMUM(1002, "상품 수량은 1개 이상이어야 합니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/yeonieum/productservice/domain/cart/service/CartProductService.java
+++ b/src/main/java/com/yeonieum/productservice/domain/cart/service/CartProductService.java
@@ -8,6 +8,7 @@ import com.yeonieum.productservice.domain.cart.exception.CartException;
 import com.yeonieum.productservice.domain.cart.repository.CartProductRepository;
 import com.yeonieum.productservice.domain.cart.repository.CartTypeRepository;
 import com.yeonieum.productservice.domain.product.entity.Product;
+import com.yeonieum.productservice.domain.product.exception.ProductException;
 import com.yeonieum.productservice.domain.product.repository.ProductRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ import java.util.List;
 import static com.yeonieum.productservice.domain.cart.exception.CartExceptionCode.CART_NOT_FOUND;
 import static com.yeonieum.productservice.domain.cart.exception.CartExceptionCode.CART_TYPE_NOT_FOUND;
 import static com.yeonieum.productservice.domain.cart.exception.CartExceptionCode.QUANTITY_BELOW_MINIMUM;
+import static com.yeonieum.productservice.domain.product.exception.ProductExceptionCode.PRODUCT_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -32,7 +34,7 @@ public class CartProductService {
     /**
      * 장바구니에 상품 등록
      * @param ofRegisterProductCart 장바구니에 등록할 상품 정보 DTO
-     * @throws IllegalStateException 존재하지 않는 상품 ID인 경우 발생
+     * @throws ProductException 존재하지 않는 상품 ID인 경우 발생
      * @throws CartException 존재하지 않는 장바구니 타입 ID인 경우 발생
      * @return 성공여부
      */
@@ -40,7 +42,7 @@ public class CartProductService {
     public boolean registerCartProduct(CartProductRequest.OfRegisterProductCart ofRegisterProductCart) {
 
         Product product = productRepository.findById(ofRegisterProductCart.getProductId())
-                .orElseThrow(() -> new IllegalStateException("존재하지 않는 상품 ID 입니다."));
+                .orElseThrow(() -> new ProductException(PRODUCT_NOT_FOUND, HttpStatus.NOT_FOUND));
 
         CartType cartType = cartTypeRepository.findById(ofRegisterProductCart.getCartTypeId())
                 .orElseThrow(() -> new CartException(CART_TYPE_NOT_FOUND, HttpStatus.NOT_FOUND));
@@ -105,7 +107,7 @@ public class CartProductService {
     /**
      * 장바구니 상품 삭제
      * @param cartProductId 장바구니 상품 ID
-     * @throws IllegalArgumentException 존재하지 않는 장바구니 ID인 경우
+     * @throws CartException 존재하지 않는 장바구니 ID인 경우
      * @return 성공 여부
      */
     @Transactional

--- a/src/main/java/com/yeonieum/productservice/domain/category/exception/CategoryExceptionCode.java
+++ b/src/main/java/com/yeonieum/productservice/domain/category/exception/CategoryExceptionCode.java
@@ -4,10 +4,10 @@ import com.yeonieum.productservice.global.exceptions.code.CustomExceptionCode;
 
 public enum CategoryExceptionCode implements CustomExceptionCode {
 
-    CATEGORY_NOT_FOUND(1300, "존재하지 않는 카테고리 ID 입니다."),
-    CATEGORY_NAME_ALREADY_EXISTS(1400, "이미 존재하는 카테고리 이름입니다."),
-    DETAIL_CATEGORY_NOT_FOUND(1500,"존재하지 않는 상세 카테고리 ID 입니다."),
-    DETAIL_CATEGORY_NAME_ALREADY_EXISTS(1600, "이미 존재하는 상세 카테고리 이름입니다.");
+    CATEGORY_NOT_FOUND(2000, "존재하지 않는 카테고리 ID 입니다."),
+    CATEGORY_NAME_ALREADY_EXISTS(2001, "이미 존재하는 카테고리 이름입니다."),
+    DETAIL_CATEGORY_NOT_FOUND(2002,"존재하지 않는 상세 카테고리 ID 입니다."),
+    DETAIL_CATEGORY_NAME_ALREADY_EXISTS(2003, "이미 존재하는 상세 카테고리 이름입니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/yeonieum/productservice/domain/customer/exception/CustomerExceptionCode.java
+++ b/src/main/java/com/yeonieum/productservice/domain/customer/exception/CustomerExceptionCode.java
@@ -4,7 +4,7 @@ import com.yeonieum.productservice.global.exceptions.code.CustomExceptionCode;
 
 public enum CustomerExceptionCode implements CustomExceptionCode {
 
-    CUSTOMER_NOT_FOUND(1700, "존재하지 않는 고객 ID 입니다.");
+    CUSTOMER_NOT_FOUND(3000, "존재하지 않는 고객 ID 입니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/yeonieum/productservice/domain/image/service/ImageService.java
+++ b/src/main/java/com/yeonieum/productservice/domain/image/service/ImageService.java
@@ -3,15 +3,19 @@ package com.yeonieum.productservice.domain.image.service;
 import com.yeonieum.productservice.domain.image.dto.ImageResponse;
 import com.yeonieum.productservice.domain.product.entity.ProductCertification;
 import com.yeonieum.productservice.domain.product.entity.ProductDetailImage;
+import com.yeonieum.productservice.domain.product.exception.ProductException;
 import com.yeonieum.productservice.domain.product.repository.ProductCertificationRepository;
 import com.yeonieum.productservice.domain.product.repository.ProductDetailImageRepository;
 import com.yeonieum.productservice.domain.product.repository.ProductRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.yeonieum.productservice.domain.product.exception.ProductExceptionCode.PRODUCT_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -24,14 +28,14 @@ public class ImageService {
     /**
      * 선택한 상품 조회시, 해당 상품의 상세 이미지 조회
      * @param productId 상품 ID
-     * @throws IllegalArgumentException 존재하지 않는 상품 ID인 경우
+     * @throws ProductException 존재하지 않는 상품 ID인 경우
      * @return 상품 상세 이미지에 대한 정보
      */
     @Transactional
     public List<ImageResponse.OfRetrieveDetailImage> retrieveProductDetailImages(Long productId) {
 
         if (!productRepository.existsById(productId)) {
-            throw new IllegalArgumentException("존재하지 않는 상품 ID 입니다.");
+            throw new ProductException(PRODUCT_NOT_FOUND, HttpStatus.NOT_FOUND);
         }
 
         List<ProductDetailImage> productDetailImages = productDetailImageRepository.findByProductId(productId);
@@ -42,14 +46,14 @@ public class ImageService {
     /**
      * 선택한 상품 조회시, 해당 상품의 인증서 정보 조회
      * @param productId 상품 ID
-     * @throws IllegalArgumentException 존재하지 않는 상품 ID인 경우
+     * @throws ProductException 존재하지 않는 상품 ID인 경우
      * @return 상품 인증서에 대한 정보
      */
     @Transactional
     public ImageResponse.OfRetrieveCertification retrieveProductCertification(Long productId) {
 
         if (!productRepository.existsById(productId)) {
-            throw new IllegalArgumentException("존재하지 않는 상품 ID 입니다.");
+            throw new ProductException(PRODUCT_NOT_FOUND, HttpStatus.NOT_FOUND);
         }
 
         ProductCertification productCertification = productCertificationRepository.findByProductId(productId);

--- a/src/main/java/com/yeonieum/productservice/domain/product/exception/ProductExceptionCode.java
+++ b/src/main/java/com/yeonieum/productservice/domain/product/exception/ProductExceptionCode.java
@@ -4,16 +4,16 @@ import com.yeonieum.productservice.global.exceptions.code.CustomExceptionCode;
 
 public enum ProductExceptionCode implements CustomExceptionCode {
 
-    PRODUCT_NOT_FOUND(1800, "존재하지 않는 상품 ID 입니다."),
-    PRODUCT_ADVERTISEMENT_NOT_FOUNT(1900, "해당하는 신청 건이 존재하지 않습니다."),
-    PRODUCT_ADVERTISEMENT_CANNOT_BE_CANCELED(2000, "취소할 수 없는 상태입니다."),
-    PRODUCT_ADVERTISEMENT_CANNOT_BE_APPROVE(2100, "승인할 수 없는 상태입니다."),
-    NOT_PRODUCT_OWNER(2200, "해당 상품의 소유자가 아닙니다."),
-    PRODUCT_TIME_SALE_NOT_FOUNT(2300, "해당하는 신청 건이 존재하지 않습니다."),
-    PRODUCT_TIME_SALE_CANNOT_BE_CANCELED(2400, "취소할 수 없는 상태입니다."),
-    NO_PRODUCTS_IN_CATEGORY(2500, "해당 카테고리 내의 상품이 없습니다."),
-    NO_PRODUCTS_IN_DETAIL_CATEGORY(2600, "해당 상세 카테고리 내의 상품이 없습니다."),
-    NO_SEARCH_RESULTS(2700, "검색 결과가 없습니다. 다른 검색어를 입력해 주세요.");
+    PRODUCT_NOT_FOUND(4000, "존재하지 않는 상품 ID 입니다."),
+    PRODUCT_ADVERTISEMENT_NOT_FOUNT(4001, "해당하는 신청 건이 존재하지 않습니다."),
+    PRODUCT_ADVERTISEMENT_CANNOT_BE_CANCELED(4002, "취소할 수 없는 상태입니다."),
+    PRODUCT_ADVERTISEMENT_CANNOT_BE_APPROVE(4003, "승인할 수 없는 상태입니다."),
+    NOT_PRODUCT_OWNER(4004, "해당 상품의 소유자가 아닙니다."),
+    PRODUCT_TIME_SALE_NOT_FOUNT(4005, "해당하는 신청 건이 존재하지 않습니다."),
+    PRODUCT_TIME_SALE_CANNOT_BE_CANCELED(4006, "취소할 수 없는 상태입니다."),
+    NO_PRODUCTS_IN_CATEGORY(4007, "해당 카테고리 내의 상품이 없습니다."),
+    NO_PRODUCTS_IN_DETAIL_CATEGORY(4008, "해당 상세 카테고리 내의 상품이 없습니다."),
+    NO_SEARCH_RESULTS(4009, "검색 결과가 없습니다. 다른 검색어를 입력해 주세요.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/yeonieum/productservice/domain/product/service/memberservice/ProductShoppingFacade.java
+++ b/src/main/java/com/yeonieum/productservice/domain/product/service/memberservice/ProductShoppingFacade.java
@@ -87,7 +87,7 @@ public class ProductShoppingFacade {
     /**
      * 상품 상세 정보 조회
      * @param productId 상품 ID
-     * @throws IllegalArgumentException 상품 ID가 존재하지 않는 경우
+     * @throws ProductException 상품 ID가 존재하지 않는 경우
      * @return 상품의 상세 정보
      */
     @Transactional

--- a/src/main/java/com/yeonieum/productservice/domain/productinventory/exception/ProductInventoryExceptionCode.java
+++ b/src/main/java/com/yeonieum/productservice/domain/productinventory/exception/ProductInventoryExceptionCode.java
@@ -4,7 +4,7 @@ import com.yeonieum.productservice.global.exceptions.code.CustomExceptionCode;
 
 public enum ProductInventoryExceptionCode implements CustomExceptionCode {
 
-    PRODUCT_INVENTORY_NOT_FOUND(2800, "해당하는 상품재고가 존재하지 않습니다.");
+    PRODUCT_INVENTORY_NOT_FOUND(5000, "해당하는 상품재고가 존재하지 않습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/yeonieum/productservice/domain/review/exception/ProductReviewExceptionCode.java
+++ b/src/main/java/com/yeonieum/productservice/domain/review/exception/ProductReviewExceptionCode.java
@@ -4,8 +4,8 @@ import com.yeonieum.productservice.global.exceptions.code.CustomExceptionCode;
 
 public enum ProductReviewExceptionCode implements CustomExceptionCode {
 
-    REVIEW_ALREADY_EXISTS(2900, "이미 해당 회원이 작성한 리뷰가 존재합니다."),
-    PRODUCT_REVIEW_NOT_FOUND(3000, "존재하지 않는 상품리뷰 ID 입니다.");
+    REVIEW_ALREADY_EXISTS(6000, "이미 해당 회원이 작성한 리뷰가 존재합니다."),
+    PRODUCT_REVIEW_NOT_FOUND(6001, "존재하지 않는 상품리뷰 ID 입니다.");
 
     private final int code;
     private final String message;


### PR DESCRIPTION
<!--

PR 제목 예시

title : [FEAT] 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- 도메인별 오류코드 정의

## #️⃣관련 이슈

- Close#{603}

## 📝세부 작업 내용

- [x] 1000 ~ : 장바구니 도메인 오류코드
- [x] 2000 ~ : 카테고리 도메인 오류코드
- [x] 3000 ~ : 고객 도메인 오류코드
- [x] 4000 ~ : 상품 도메인 오류코드
- [x] 5000 ~ : 상품재고 도메인 오류코드
- [x] 6000 ~ : 상품리뷰 도메인 오류코드

## 💬참고 사항