### PR TITLE
KAN-701 feat: cors 도메인 추가

### DIFF
--- a/src/main/java/com/yeonieum/productservice/global/config/CorsConfig.java
+++ b/src/main/java/com/yeonieum/productservice/global/config/CorsConfig.java
@@ -12,6 +12,11 @@ import java.util.Arrays;
 public class CorsConfig implements WebMvcConfigurer {
     @Value("${cors.allowed.origin}")
     private String CORS_ALLOWED_ORIGIN;
+
+    @Value("${cors.allowed.origin.yeonieum}")
+    private String CORS_ALLOWED_ORIGIN_YEONIEUM;
+    @Value("${cors.allowed.origin.dashboard}")
+    private String CORS_ALLOWED_ORIGIN_DASHBOARD;
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         CorsConfiguration corsConfiguration = new CorsConfiguration();
@@ -19,11 +24,11 @@ public class CorsConfig implements WebMvcConfigurer {
         corsConfiguration.setAllowedHeaders(Arrays.asList("Content-Type", "application/json", "Authorization", "Bearer"));
         corsConfiguration.addExposedHeader("Bearer");
         corsConfiguration.addExposedHeader("provider");
-        corsConfiguration.setAllowedOrigins(Arrays.asList("http://localhost:5173", "http://localhost:5174", "http://localhost:3000",CORS_ALLOWED_ORIGIN));
+        corsConfiguration.setAllowedOrigins(Arrays.asList("http://localhost:5173", "http://localhost:5174", "http://localhost:3000",CORS_ALLOWED_ORIGIN, CORS_ALLOWED_ORIGIN_YEONIEUM, CORS_ALLOWED_ORIGIN_DASHBOARD));
         corsConfiguration.setAllowedMethods(Arrays.asList("GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS"));
 
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173", "http://localhost:5174","http://localhost:3000", CORS_ALLOWED_ORIGIN)
+                .allowedOrigins("http://localhost:5173", "http://localhost:5174","http://localhost:3000", CORS_ALLOWED_ORIGIN, CORS_ALLOWED_ORIGIN_YEONIEUM, CORS_ALLOWED_ORIGIN_DASHBOARD)
                 .allowedMethods("GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS")
                 .allowedHeaders("Content-Type", "application/json", "Authorization", "Bearer")
                 .exposedHeaders("Bearer", "provider")


### PR DESCRIPTION
[![KAN-701](https://badgen.net/badge/JIRA/KAN-701/blue?icon=jira)](https://jira.company.com/browse/KAN-701) [![PR-148](https://badgen.net/badge/Preview/PR-148/blue)](https://pr-148.company.com) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=HS-Continuity&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--

PR 제목 예시

title : KAN-000 feat: 소셜 로그인 기능 구현

-->

## ⚒️구현 기능

- cors 도메인 추가

## #️⃣관련 이슈

- jira 이슈번호

## 📝세부 작업 내용

- [ ] ex) 공통 컴포넌트 header 구현
- [ ] To-do 1
- [ ] To-do 2
- [ ] To-do 3

## 💬참고 사항

- 리뷰어에게 참고할만한 사항을 입력해주세요.

[KAN-701]: https://hysoung-kosa-team4.atlassian.net/browse/KAN-701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ